### PR TITLE
Add support for Laravel 5.4

### DIFF
--- a/src/Casinelli/CampaignMonitor/CampaignMonitorServiceProvider.php
+++ b/src/Casinelli/CampaignMonitor/CampaignMonitorServiceProvider.php
@@ -19,7 +19,7 @@ class CampaignMonitorServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../../config/campaignmonitor.php', 'campaignmonitor');
 
-        $this->app['campaignmonitor'] = $this->app->share(function ($app) {
+        $this->app->singleton('campaignmonitor', function ($app) {
             return new CampaignMonitor($app);
         });
     }


### PR DESCRIPTION
The `share` method has been removed in the container as it was superfluous and not documented. The `singleton` method can be used instead. See the upgrade guide for more info: https://laravel.com/docs/5.4/upgrade